### PR TITLE
Describe STANAGs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ NGA intends to retire its current traditional data center and replace it with a 
 6. Attachment 04b: [MTI Backlog](04b_Backlog.md)
 7. Attachment 05: [Clauses & Provisions](05_Clauses_and_Provisions.pdf)
 
+## STANAGs
+
+This RFP cites two “STANAGs,” or NATO STANdardization AGreements, that this work relies on: STANAG 4607 and STANAG 4676. These function like ISO or ANSI standards, but are instead promulgated by the North Atlantic Treaty Organization. There are [STANAGs on many topics](http://nso.nato.int/nso/nsdd/listpromulg.html), some technical, most not. The work here requires parsing both of these STANAG file formats.
+
+### STANAG 4607
+4607 defines the NATO [Ground Moving Target Indicator](https://en.wikipedia.org/wiki/Moving_target_indication) (GMTI) format—radar, basically. The NATO Standards Office publishes both [the standard itself](http://nso.nato.int/nso/zPublic/stanags/CURRENT/4607Eed03.pdf) and [an implementation guide](http://nso.nato.int/nso/zPublic/ap/aedp-7(2).pdf). MITRE publishes [an interesting history](https://www.mitre.org/sites/default/files/pdf/05_0164.pdf) of how the 4607 standard came to be. To get an idea of what it looks like to interact with GMTI [see this open source GMTI library](https://github.com/pentlandedge/s4607), [these open source GMTI utilities](https://github.com/pentlandedge/s4607_extra), or [this Leaflet-based GMTI viewer](http://www.hawkstream.net/), which includes sample data.
+
+### STANAG 4676
+4676 is the NATO Intelligence, Surveillance and Reconnaissance Tracking Standard, establishing the standard for tracking the location and spatial movement of mobile objects and associated motion imagry. [The standard](http://nso.nato.int/nso/zPublic/ap/AEDP-12(A)V1.pdf) defines an XML schema.
+
 
 ## Public domain
 


### PR DESCRIPTION
"STANAG" is not an acronym that many vendors are likely to be familiar with, and can serve as an unnecessarily intimidating barrier. By explaining both the term itself and the purpose of the two STANAGs relevant to this work will help people to understand the core of the work to be done, and reduce uncertainty for them.